### PR TITLE
Feat/menu 메뉴 도전 기능 최종 점검 완료

### DIFF
--- a/src/main/java/com/example/foodduck/common/config/jwt/SecurityConfig.java
+++ b/src/main/java/com/example/foodduck/common/config/jwt/SecurityConfig.java
@@ -35,7 +35,7 @@ public class SecurityConfig {
                 .requestMatchers(HttpMethod.GET, "/stores/{storeId}/menus").permitAll()
                 .requestMatchers("/users/logout").authenticated()
                 .requestMatchers("/stores/**").hasAuthority("ROLE_OWNER") //TODO 경로 깔끔하게 변경
-                .requestMatchers("/menus/{storeid}","/menus/{menuId}/update", "menus/{menuId}/delete", "/menus/{menuId}/options", "/menus/options/{optionId}/option-update").hasAuthority("ROLE_OWNER")
+                .requestMatchers("/menus/{storeid}","/menus/{menuId}/update", "menus/{menuId}/delete", "/menus/{menuId}/options", "/menus/options/{optionId}/option-update","menus/options/{optionId}/delete" ).hasAuthority("ROLE_OWNER")
                 .requestMatchers("/orders/request").hasRole("USER")
                 .anyRequest().authenticated()
             )

--- a/src/main/java/com/example/foodduck/common/config/jwt/SecurityConfig.java
+++ b/src/main/java/com/example/foodduck/common/config/jwt/SecurityConfig.java
@@ -34,8 +34,15 @@ public class SecurityConfig {
                 .requestMatchers("/users/register", "/users/login", "menus/{menuId}").permitAll()
                 .requestMatchers(HttpMethod.GET, "/stores/{storeId}/menus").permitAll()
                 .requestMatchers("/users/logout").authenticated()
-                .requestMatchers("/stores/**").hasAuthority("ROLE_OWNER") //TODO 경로 깔끔하게 변경
-                .requestMatchers("/menus/{storeid}","/menus/{menuId}/update", "menus/{menuId}/delete", "/menus/{menuId}/options", "/menus/options/{optionId}/option-update","menus/options/{optionId}/delete" ).hasAuthority("ROLE_OWNER")
+                .requestMatchers("/stores/**").hasAuthority("ROLE_OWNER")
+                .requestMatchers(
+                        "/menus/{storeid}",
+                        "/menus/{menuId}/update",
+                        "/menus/{menuId}/delete",
+                        "/menus/{menuId}/options",
+                        "/menus/options/{optionId}/update",
+                        "/menus/options/{optionId}/delete"
+                ).hasAuthority("ROLE_OWNER")
                 .requestMatchers("/orders/request").hasRole("USER")
                 .anyRequest().authenticated()
             )

--- a/src/main/java/com/example/foodduck/common/config/jwt/SecurityConfig.java
+++ b/src/main/java/com/example/foodduck/common/config/jwt/SecurityConfig.java
@@ -35,7 +35,7 @@ public class SecurityConfig {
                 .requestMatchers(HttpMethod.GET, "/stores/{storeId}/menus").permitAll()
                 .requestMatchers("/users/logout").authenticated()
                 .requestMatchers("/stores/**").hasAuthority("ROLE_OWNER")
-                .requestMatchers("/menus/{storeid}","/menus/{menuId}/update", "menus/{menuId}/delete").hasAuthority("ROLE_OWNER")
+                .requestMatchers("/menus/{storeid}","/menus/{menuId}/update", "menus/{menuId}/delete", "/menus/{menuId}/options").hasAuthority("ROLE_OWNER")
                 .requestMatchers("/orders/request").hasRole("USER")
                 .anyRequest().authenticated()
             )

--- a/src/main/java/com/example/foodduck/common/config/jwt/SecurityConfig.java
+++ b/src/main/java/com/example/foodduck/common/config/jwt/SecurityConfig.java
@@ -6,6 +6,7 @@ import com.example.foodduck.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -30,11 +31,12 @@ public class SecurityConfig {
         http
             .csrf().disable()
             .authorizeHttpRequests(auth -> auth
-                .requestMatchers("/users/register", "/users/login", "menus", "menus/{menuId}").permitAll()
+                .requestMatchers("/users/register", "/users/login", "menus/{menuId}").permitAll()
+                .requestMatchers(HttpMethod.GET, "/stores/{storeId}/menus").permitAll()
                 .requestMatchers("/users/logout").authenticated()
                 .requestMatchers("/stores/**").hasAuthority("ROLE_OWNER")
                 .requestMatchers("/menus/{storeid}","/menus/{menuId}/update", "menus/{menuId}/delete").hasAuthority("ROLE_OWNER")
-                    .requestMatchers("/orders/request").hasRole("USER")
+                .requestMatchers("/orders/request").hasRole("USER")
                 .anyRequest().authenticated()
             )
             .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))

--- a/src/main/java/com/example/foodduck/common/config/jwt/SecurityConfig.java
+++ b/src/main/java/com/example/foodduck/common/config/jwt/SecurityConfig.java
@@ -34,8 +34,8 @@ public class SecurityConfig {
                 .requestMatchers("/users/register", "/users/login", "menus/{menuId}").permitAll()
                 .requestMatchers(HttpMethod.GET, "/stores/{storeId}/menus").permitAll()
                 .requestMatchers("/users/logout").authenticated()
-                .requestMatchers("/stores/**").hasAuthority("ROLE_OWNER")
-                .requestMatchers("/menus/{storeid}","/menus/{menuId}/update", "menus/{menuId}/delete", "/menus/{menuId}/options").hasAuthority("ROLE_OWNER")
+                .requestMatchers("/stores/**").hasAuthority("ROLE_OWNER") //TODO 경로 깔끔하게 변경
+                .requestMatchers("/menus/{storeid}","/menus/{menuId}/update", "menus/{menuId}/delete", "/menus/{menuId}/options", "/menus/options/{optionId}/option-update").hasAuthority("ROLE_OWNER")
                 .requestMatchers("/orders/request").hasRole("USER")
                 .anyRequest().authenticated()
             )

--- a/src/main/java/com/example/foodduck/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/foodduck/exception/GlobalExceptionHandler.java
@@ -2,6 +2,7 @@ package com.example.foodduck.exception;
 
 import jakarta.persistence.EntityNotFoundException;
 import org.apache.coyote.BadRequestException;
+import org.springframework.dao.InvalidDataAccessApiUsageException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.FieldError;
@@ -43,6 +44,12 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(MinimumOrderAmountException.class)
     public ResponseEntity<String> handleMinimumOrderAmountException(MinimumOrderAmountException ex) {
         return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(ex.getMessage());
+    }
+
+    // Param을 통해 입력된 값이 올바르지 않을 때에 대한 예외처리: 400
+    @ExceptionHandler(InvalidDataAccessApiUsageException.class)
+    public ResponseEntity<String> handleInvalidDataAccessApiUsageException(InvalidDataAccessApiUsageException ex) {
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body("입력된 조건이 올바르지 않습니다. 확인 후 다시 시도해주세요.");
     }
 
     @ExceptionHandler(MethodArgumentNotValidException.class)

--- a/src/main/java/com/example/foodduck/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/foodduck/exception/GlobalExceptionHandler.java
@@ -49,12 +49,6 @@ public class GlobalExceptionHandler {
         return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(ex.getMessage());
     }
 
-    // Param을 통해 입력된 값이 올바르지 않을 때에 대한 예외처리: 400
-    @ExceptionHandler(InvalidDataAccessApiUsageException.class)
-    public ResponseEntity<String> handleInvalidDataAccessApiUsageException(InvalidDataAccessApiUsageException ex) {
-        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body("입력된 조건이 올바르지 않습니다. 확인 후 다시 시도해주세요.");
-    }
-
     @ExceptionHandler(MethodArgumentNotValidException.class)
     public ResponseEntity<List<String>> handleException(MethodArgumentNotValidException ex) {
         List<FieldError> fieldErrors = ex.getBindingResult().getFieldErrors();

--- a/src/main/java/com/example/foodduck/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/foodduck/exception/GlobalExceptionHandler.java
@@ -1,6 +1,7 @@
 package com.example.foodduck.exception;
 
 import jakarta.persistence.EntityNotFoundException;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.coyote.BadRequestException;
 import org.springframework.dao.InvalidDataAccessApiUsageException;
 import org.springframework.http.HttpStatus;
@@ -12,6 +13,7 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 import java.util.List;
 
+@Slf4j
 @RestControllerAdvice
 public class GlobalExceptionHandler {
     @ExceptionHandler(IllegalArgumentException.class)
@@ -21,6 +23,7 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(Exception.class)
     public ResponseEntity<String> handleException(Exception ex) {
+        log.info(ex.getMessage());
         return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body("서버 오류가 발생했습니다.");
     }
 

--- a/src/main/java/com/example/foodduck/menu/controller/MenuController.java
+++ b/src/main/java/com/example/foodduck/menu/controller/MenuController.java
@@ -19,7 +19,7 @@ public class MenuController {
 
     private final MenuService menuService;
 
-    @PostMapping("/menus/{storeId}")
+    @PostMapping("stores/{storeId}/menus")
     public ResponseEntity<MenuCreateResponse> createMenu(
             @PathVariable Long storeId,
             @Valid @RequestBody MenuCreateRequest menuCreateRequest
@@ -27,13 +27,17 @@ public class MenuController {
         return new ResponseEntity<>(menuService.createMenu(storeId, menuCreateRequest), HttpStatus.CREATED);
     }
 
-    @GetMapping("/menus")
+    @GetMapping("stores/{storeId}/menus")
     public ResponseEntity<Page<MenuResponse>> getMenus(
+            @PathVariable Long storeId,
             @RequestParam (defaultValue = "1") int page,
-            @RequestParam (defaultValue = "10") int size
+            @RequestParam (defaultValue = "10") int size,
+            @RequestParam (required = false) String menuName,
+            @RequestParam (required = false) String category,
+            @RequestParam (defaultValue = "createdAt") String sortCondition
 
     ) {
-        return new ResponseEntity<>(menuService.getMenus(page,size), HttpStatus.OK);
+        return new ResponseEntity<>(menuService.getMenus(storeId, page,size, menuName, category, sortCondition), HttpStatus.OK);
     }
 
     @GetMapping("/menus/{menuId}")

--- a/src/main/java/com/example/foodduck/menu/controller/MenuController.java
+++ b/src/main/java/com/example/foodduck/menu/controller/MenuController.java
@@ -5,6 +5,7 @@ import com.example.foodduck.menu.dto.request.MenuUpdateRequest;
 import com.example.foodduck.menu.dto.response.MenuCreateResponse;
 import com.example.foodduck.menu.dto.response.MenuResponse;
 import com.example.foodduck.menu.dto.response.MenuUpdateResponse;
+import com.example.foodduck.menu.dto.response.MenuWithOptionResponse;
 import com.example.foodduck.menu.service.MenuService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -40,7 +41,7 @@ public class MenuController {
     }
 
     @GetMapping("/menus/{menuId}")
-    public ResponseEntity<MenuResponse> getMenu(@PathVariable Long menuId) {
+    public ResponseEntity<MenuWithOptionResponse> getMenu(@PathVariable Long menuId) {
         return ResponseEntity.ok(menuService.getMenu(menuId));
     }
 

--- a/src/main/java/com/example/foodduck/menu/controller/MenuController.java
+++ b/src/main/java/com/example/foodduck/menu/controller/MenuController.java
@@ -9,7 +9,6 @@ import com.example.foodduck.menu.service.MenuService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -24,7 +23,7 @@ public class MenuController {
             @PathVariable Long storeId,
             @Valid @RequestBody MenuCreateRequest menuCreateRequest
     ) {
-        return new ResponseEntity<>(menuService.createMenu(storeId, menuCreateRequest), HttpStatus.CREATED);
+        return ResponseEntity.ok(menuService.createMenu(storeId, menuCreateRequest));
     }
 
     @GetMapping("stores/{storeId}/menus")
@@ -37,12 +36,12 @@ public class MenuController {
             @RequestParam (defaultValue = "createdAt") String sortCondition
 
     ) {
-        return new ResponseEntity<>(menuService.getMenus(storeId, page,size, menuName, category, sortCondition), HttpStatus.OK);
+        return ResponseEntity.ok(menuService.getMenus(storeId, page, size, menuName, category, sortCondition));
     }
 
     @GetMapping("/menus/{menuId}")
     public ResponseEntity<MenuResponse> getMenu(@PathVariable Long menuId) {
-        return new ResponseEntity<>(menuService.getMenu(menuId), HttpStatus.OK);
+        return ResponseEntity.ok(menuService.getMenu(menuId));
     }
 
     @PatchMapping("/menus/{menuId}/update")
@@ -50,12 +49,12 @@ public class MenuController {
             @PathVariable Long menuId,
             @Valid @RequestBody MenuUpdateRequest menuUpdateRequest
     ) {
-        return new ResponseEntity<>(menuService.updateMenu(menuId, menuUpdateRequest), HttpStatus.OK);
+        return ResponseEntity.ok(menuService.updateMenu(menuId, menuUpdateRequest));
     }
 
     @DeleteMapping("/menus/{menuId}/delete")
     public ResponseEntity<Void> deleteMenu(@PathVariable Long menuId) {
         menuService.deleteMenu(menuId);
-        return new ResponseEntity<>(HttpStatus.OK);
+        return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/example/foodduck/menu/controller/MenuController.java
+++ b/src/main/java/com/example/foodduck/menu/controller/MenuController.java
@@ -18,7 +18,7 @@ public class MenuController {
 
     private final MenuService menuService;
 
-    @PostMapping("stores/{storeId}/menus")
+    @PostMapping("/stores/{storeId}/menus")
     public ResponseEntity<MenuCreateResponse> createMenu(
             @PathVariable Long storeId,
             @Valid @RequestBody MenuCreateRequest menuCreateRequest
@@ -26,7 +26,7 @@ public class MenuController {
         return ResponseEntity.ok(menuService.createMenu(storeId, menuCreateRequest));
     }
 
-    @GetMapping("stores/{storeId}/menus")
+    @GetMapping("/stores/{storeId}/menus")
     public ResponseEntity<Page<MenuResponse>> getMenus(
             @PathVariable Long storeId,
             @RequestParam (defaultValue = "1") int page,

--- a/src/main/java/com/example/foodduck/menu/controller/MenuOptionController.java
+++ b/src/main/java/com/example/foodduck/menu/controller/MenuOptionController.java
@@ -31,5 +31,12 @@ public class MenuOptionController {
         return ResponseEntity.ok(menuOptionService.updateMenuOption(optionId, menuOptionUpdateRequest));
     }
 
+    @DeleteMapping("menus/options/{optionId}/delete")
+    public ResponseEntity<Void> deleteMenuOption(@PathVariable Long optionId) {
+        menuOptionService.deleteMenuOption(optionId);
+
+        return ResponseEntity.noContent().build();
+    }
+
 
 }

--- a/src/main/java/com/example/foodduck/menu/controller/MenuOptionController.java
+++ b/src/main/java/com/example/foodduck/menu/controller/MenuOptionController.java
@@ -23,7 +23,7 @@ public class MenuOptionController {
         return ResponseEntity.ok(menuOptionService.createMenuOption(menuId, menuOptionCreateRequest));
     }
 
-    @PatchMapping("/menus/options/{optionId}/option-update")
+    @PatchMapping("/menus/options/{optionId}/update")
     public ResponseEntity<MenuOptionUpdateResponse> updateMenuOption (
             @PathVariable Long optionId,
             @Valid @RequestBody MenuOptionUpdateRequest menuOptionUpdateRequest

--- a/src/main/java/com/example/foodduck/menu/controller/MenuOptionController.java
+++ b/src/main/java/com/example/foodduck/menu/controller/MenuOptionController.java
@@ -1,0 +1,27 @@
+package com.example.foodduck.menu.controller;
+
+import com.example.foodduck.menu.dto.request.MenuOptionCreateRequest;
+import com.example.foodduck.menu.dto.response.MenuOptionCreateResponse;
+import com.example.foodduck.menu.service.MenuOptionService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class MenuOptionController {
+    private final MenuOptionService menuOptionService;
+
+    @PostMapping("/menus/{menuId}/options")
+    public ResponseEntity<MenuOptionCreateResponse> createMenuOption (
+            @PathVariable Long menuId,
+            @Valid @RequestBody MenuOptionCreateRequest menuOptionCreateRequest
+    ) {
+        return ResponseEntity.ok(menuOptionService.createMenuOption(menuId, menuOptionCreateRequest));
+    }
+
+}

--- a/src/main/java/com/example/foodduck/menu/controller/MenuOptionController.java
+++ b/src/main/java/com/example/foodduck/menu/controller/MenuOptionController.java
@@ -1,15 +1,14 @@
 package com.example.foodduck.menu.controller;
 
 import com.example.foodduck.menu.dto.request.MenuOptionCreateRequest;
+import com.example.foodduck.menu.dto.request.MenuOptionUpdateRequest;
+import com.example.foodduck.menu.dto.response.MenuOptionUpdateResponse;
 import com.example.foodduck.menu.dto.response.MenuOptionCreateResponse;
 import com.example.foodduck.menu.service.MenuOptionService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -23,5 +22,14 @@ public class MenuOptionController {
     ) {
         return ResponseEntity.ok(menuOptionService.createMenuOption(menuId, menuOptionCreateRequest));
     }
+
+    @PatchMapping("/menus/options/{optionId}/option-update")
+    public ResponseEntity<MenuOptionUpdateResponse> updateMenuOption (
+            @PathVariable Long optionId,
+            @Valid @RequestBody MenuOptionUpdateRequest menuOptionUpdateRequest
+    ) {
+        return ResponseEntity.ok(menuOptionService.updateMenuOption(optionId, menuOptionUpdateRequest));
+    }
+
 
 }

--- a/src/main/java/com/example/foodduck/menu/dto/request/MenuCreateRequest.java
+++ b/src/main/java/com/example/foodduck/menu/dto/request/MenuCreateRequest.java
@@ -1,13 +1,14 @@
 package com.example.foodduck.menu.dto.request;
 
-import com.example.foodduck.menu.entity.MenuState;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.PositiveOrZero;
 import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 @Getter
+@AllArgsConstructor
 public class MenuCreateRequest {
 
     @NotBlank(message = "메뉴 이름을 입력해 주세요.")
@@ -17,5 +18,9 @@ public class MenuCreateRequest {
     @NotNull(message = "가격을 입력해 주세요.")
     @PositiveOrZero
     private int price;
+
+    @NotBlank(message = "카테고리를 입력해 주세요.")
+    @Size(min = 1, max = 30)
+    private String category;
 
 }

--- a/src/main/java/com/example/foodduck/menu/dto/request/MenuCreateRequest.java
+++ b/src/main/java/com/example/foodduck/menu/dto/request/MenuCreateRequest.java
@@ -4,11 +4,10 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.PositiveOrZero;
 import jakarta.validation.constraints.Size;
-import lombok.AllArgsConstructor;
+
 import lombok.Getter;
 
 @Getter
-@AllArgsConstructor
 public class MenuCreateRequest {
 
     @NotBlank(message = "메뉴 이름을 입력해 주세요.")

--- a/src/main/java/com/example/foodduck/menu/dto/request/MenuOptionCreateRequest.java
+++ b/src/main/java/com/example/foodduck/menu/dto/request/MenuOptionCreateRequest.java
@@ -4,11 +4,10 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.PositiveOrZero;
 import jakarta.validation.constraints.Size;
-import lombok.AllArgsConstructor;
+
 import lombok.Getter;
 
 @Getter
-@AllArgsConstructor
 public class MenuOptionCreateRequest {
 
     @NotBlank(message = "메뉴 옵션을 입력해주세요.")
@@ -21,5 +20,5 @@ public class MenuOptionCreateRequest {
 
     @NotNull(message = "가격을 입력해주세요.")
     @PositiveOrZero
-    private int price;
+    private int optionPrice;
 }

--- a/src/main/java/com/example/foodduck/menu/dto/request/MenuOptionCreateRequest.java
+++ b/src/main/java/com/example/foodduck/menu/dto/request/MenuOptionCreateRequest.java
@@ -1,0 +1,25 @@
+package com.example.foodduck.menu.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.PositiveOrZero;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class MenuOptionCreateRequest {
+
+    @NotBlank(message = "메뉴 옵션을 입력해주세요.")
+    @Size(min = 1, max = 30)
+    private String optionName;
+
+    @NotBlank(message = "옵션 내용을 입력해주세요.")
+    @Size(min = 1, max = 50)
+    private String contents;
+
+    @NotNull(message = "가격을 입력해주세요.")
+    @PositiveOrZero
+    private int price;
+}

--- a/src/main/java/com/example/foodduck/menu/dto/request/MenuOptionUpdateRequest.java
+++ b/src/main/java/com/example/foodduck/menu/dto/request/MenuOptionUpdateRequest.java
@@ -1,0 +1,21 @@
+package com.example.foodduck.menu.dto.request;
+
+import com.example.foodduck.menu.entity.OptionStatus;
+import jakarta.validation.constraints.PositiveOrZero;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+
+@Getter
+public class MenuOptionUpdateRequest {
+
+    @Size(min = 1, max = 30)
+    private String option;
+
+    @Size(min = 1, max = 50)
+    private String contents;
+
+    @PositiveOrZero
+    private int price;
+
+    private OptionStatus optionStatus;
+}

--- a/src/main/java/com/example/foodduck/menu/dto/request/MenuOptionUpdateRequest.java
+++ b/src/main/java/com/example/foodduck/menu/dto/request/MenuOptionUpdateRequest.java
@@ -15,7 +15,7 @@ public class MenuOptionUpdateRequest {
     private String contents;
 
     @PositiveOrZero
-    private int price;
+    private int optionPrice;
 
     private OptionStatus optionStatus;
 }

--- a/src/main/java/com/example/foodduck/menu/dto/request/MenuUpdateRequest.java
+++ b/src/main/java/com/example/foodduck/menu/dto/request/MenuUpdateRequest.java
@@ -13,6 +13,9 @@ public class MenuUpdateRequest {
     @PositiveOrZero
     private int price;
 
+    private String category;
+
     private MenuState menuState;
+
 
 }

--- a/src/main/java/com/example/foodduck/menu/dto/request/MenuUpdateRequest.java
+++ b/src/main/java/com/example/foodduck/menu/dto/request/MenuUpdateRequest.java
@@ -13,6 +13,7 @@ public class MenuUpdateRequest {
     @PositiveOrZero
     private int price;
 
+    @Size(min = 1, max = 30)
     private String category;
 
     private MenuState menuState;

--- a/src/main/java/com/example/foodduck/menu/dto/response/MenuCreateResponse.java
+++ b/src/main/java/com/example/foodduck/menu/dto/response/MenuCreateResponse.java
@@ -20,17 +20,6 @@ public class MenuCreateResponse {
     private final LocalDateTime createdAt;
     private final LocalDateTime updatedAt;
 
-    public MenuCreateResponse(Long id, Long storeId, String menuName, int price,String category, MenuState menuState, LocalDateTime createdAt, LocalDateTime updatedAt) {
-        this.id = id;
-        this.storeId = storeId;
-        this.menuName = menuName;
-        this.price = price;
-        this.category =category;
-        this.menuState = menuState;
-        this.createdAt = createdAt;
-        this.updatedAt = updatedAt;
-    }
-
     public static MenuCreateResponse toDto(Menu menu) {
         return MenuCreateResponse.builder()
                 .id(menu.getId())

--- a/src/main/java/com/example/foodduck/menu/dto/response/MenuCreateResponse.java
+++ b/src/main/java/com/example/foodduck/menu/dto/response/MenuCreateResponse.java
@@ -16,17 +16,20 @@ public class MenuCreateResponse {
 
     private final int price;
 
+    private final String category;
+
     private final MenuState menuState;
 
     private final LocalDateTime createdAt;
 
     private final LocalDateTime updatedAt;
 
-    public MenuCreateResponse(Long id, Long storeId, String menuName, int price, MenuState menuState, LocalDateTime createdAt, LocalDateTime updatedAt) {
+    public MenuCreateResponse(Long id, Long storeId, String menuName, int price,String category, MenuState menuState, LocalDateTime createdAt, LocalDateTime updatedAt) {
         this.id = id;
         this.storeId = storeId;
         this.menuName = menuName;
         this.price = price;
+        this.category =category;
         this.menuState = menuState;
         this.createdAt = createdAt;
         this.updatedAt = updatedAt;
@@ -39,6 +42,7 @@ public class MenuCreateResponse {
             menu.getStore().getId(),
             menu.getMenuName(),
             menu.getPrice(),
+            menu.getCategory(),
             menu.getMenuState(),
             menu.getCreatedAt(),
             menu.getUpdatedAt()

--- a/src/main/java/com/example/foodduck/menu/dto/response/MenuCreateResponse.java
+++ b/src/main/java/com/example/foodduck/menu/dto/response/MenuCreateResponse.java
@@ -2,26 +2,22 @@ package com.example.foodduck.menu.dto.response;
 
 import com.example.foodduck.menu.entity.Menu;
 import com.example.foodduck.menu.entity.MenuState;
+import lombok.Builder;
 import lombok.Getter;
 
 import java.time.LocalDateTime;
 
 @Getter
+@Builder
 public class MenuCreateResponse {
+
     private final Long id;
-
     private final Long storeId;
-
     private final String menuName;
-
     private final int price;
-
     private final String category;
-
     private final MenuState menuState;
-
     private final LocalDateTime createdAt;
-
     private final LocalDateTime updatedAt;
 
     public MenuCreateResponse(Long id, Long storeId, String menuName, int price,String category, MenuState menuState, LocalDateTime createdAt, LocalDateTime updatedAt) {
@@ -35,17 +31,16 @@ public class MenuCreateResponse {
         this.updatedAt = updatedAt;
     }
 
-    //TODO: Builder로 변경
     public static MenuCreateResponse toDto(Menu menu) {
-        return new MenuCreateResponse (
-            menu.getId(),
-            menu.getStore().getId(),
-            menu.getMenuName(),
-            menu.getPrice(),
-            menu.getCategory(),
-            menu.getMenuState(),
-            menu.getCreatedAt(),
-            menu.getUpdatedAt()
-        );
+        return MenuCreateResponse.builder()
+                .id(menu.getId())
+                .storeId(menu.getStore().getId())
+                .menuName(menu.getMenuName())
+                .price(menu.getPrice())
+                .category(menu.getCategory())
+                .menuState(menu.getMenuState())
+                .createdAt(menu.getCreatedAt())
+                .updatedAt(menu.getUpdatedAt())
+                .build();
     }
 }

--- a/src/main/java/com/example/foodduck/menu/dto/response/MenuOptionCreateResponse.java
+++ b/src/main/java/com/example/foodduck/menu/dto/response/MenuOptionCreateResponse.java
@@ -2,50 +2,45 @@ package com.example.foodduck.menu.dto.response;
 
 import com.example.foodduck.menu.entity.MenuOption;
 import com.example.foodduck.menu.entity.OptionStatus;
+import lombok.Builder;
 import lombok.Getter;
 
 import java.time.LocalDateTime;
 
 @Getter
+@Builder
 public class MenuOptionCreateResponse {
+
     private final Long id;
-
     private final Long menuId;
-
     private final String optionName;
-
     private final String contents;
-
-    private final int price;
-
+    private final int optionPrice;
     private final OptionStatus optionStatus;
-
     private final LocalDateTime createdAt;
-
     private final LocalDateTime updatedAt;
 
-    public MenuOptionCreateResponse(Long id, Long menuId, String optionName, String contents, int price, OptionStatus optionStatus, LocalDateTime createdAt, LocalDateTime updatedAt) {
+    public MenuOptionCreateResponse(Long id, Long menuId, String optionName, String contents, int optionPrice, OptionStatus optionStatus, LocalDateTime createdAt, LocalDateTime updatedAt) {
         this.id = id;
         this.menuId = menuId;
         this.optionName = optionName;
         this.contents = contents;
-        this.price = price;
+        this.optionPrice = optionPrice;
         this.optionStatus = optionStatus;
         this.createdAt = createdAt;
         this.updatedAt = updatedAt;
     }
 
-    //TODO: Builder로 변경
     public static MenuOptionCreateResponse toDto(MenuOption menuOption) {
-        return new MenuOptionCreateResponse(
-                menuOption.getId(),
-                menuOption.getMenu().getId(),
-                menuOption.getOptionName(),
-                menuOption.getContents(),
-                menuOption.getOptionPrice(),
-                menuOption.getOptionStatus(),
-                menuOption.getCreatedAt(),
-                menuOption.getUpdatedAt()
-        );
+        return MenuOptionCreateResponse.builder()
+                .id(menuOption.getId())
+                .menuId(menuOption.getMenu().getId())
+                .optionName(menuOption.getOptionName())
+                .contents(menuOption.getContents())
+                .optionPrice(menuOption.getOptionPrice())
+                .optionStatus(menuOption.getOptionStatus())
+                .createdAt(menuOption.getCreatedAt())
+                .updatedAt(menuOption.getUpdatedAt())
+                .build();
     }
 }

--- a/src/main/java/com/example/foodduck/menu/dto/response/MenuOptionCreateResponse.java
+++ b/src/main/java/com/example/foodduck/menu/dto/response/MenuOptionCreateResponse.java
@@ -1,0 +1,51 @@
+package com.example.foodduck.menu.dto.response;
+
+import com.example.foodduck.menu.entity.MenuOption;
+import com.example.foodduck.menu.entity.OptionStatus;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+public class MenuOptionCreateResponse {
+    private final Long id;
+
+    private final Long menuId;
+
+    private final String optionName;
+
+    private final String contents;
+
+    private final int price;
+
+    private final OptionStatus optionStatus;
+
+    private final LocalDateTime createdAt;
+
+    private final LocalDateTime updatedAt;
+
+    public MenuOptionCreateResponse(Long id, Long menuId, String optionName, String contents, int price, OptionStatus optionStatus, LocalDateTime createdAt, LocalDateTime updatedAt) {
+        this.id = id;
+        this.menuId = menuId;
+        this.optionName = optionName;
+        this.contents = contents;
+        this.price = price;
+        this.optionStatus = optionStatus;
+        this.createdAt = createdAt;
+        this.updatedAt = updatedAt;
+    }
+
+    //TODO: Builder로 변경
+    public static MenuOptionCreateResponse toDto(MenuOption menuOption) {
+        return new MenuOptionCreateResponse(
+                menuOption.getId(),
+                menuOption.getMenu().getId(),
+                menuOption.getOptionName(),
+                menuOption.getContents(),
+                menuOption.getOptionPrice(),
+                menuOption.getOptionStatus(),
+                menuOption.getCreatedAt(),
+                menuOption.getUpdatedAt()
+        );
+    }
+}

--- a/src/main/java/com/example/foodduck/menu/dto/response/MenuOptionCreateResponse.java
+++ b/src/main/java/com/example/foodduck/menu/dto/response/MenuOptionCreateResponse.java
@@ -20,17 +20,6 @@ public class MenuOptionCreateResponse {
     private final LocalDateTime createdAt;
     private final LocalDateTime updatedAt;
 
-    public MenuOptionCreateResponse(Long id, Long menuId, String optionName, String contents, int optionPrice, OptionStatus optionStatus, LocalDateTime createdAt, LocalDateTime updatedAt) {
-        this.id = id;
-        this.menuId = menuId;
-        this.optionName = optionName;
-        this.contents = contents;
-        this.optionPrice = optionPrice;
-        this.optionStatus = optionStatus;
-        this.createdAt = createdAt;
-        this.updatedAt = updatedAt;
-    }
-
     public static MenuOptionCreateResponse toDto(MenuOption menuOption) {
         return MenuOptionCreateResponse.builder()
                 .id(menuOption.getId())

--- a/src/main/java/com/example/foodduck/menu/dto/response/MenuOptionUpdateResponse.java
+++ b/src/main/java/com/example/foodduck/menu/dto/response/MenuOptionUpdateResponse.java
@@ -20,17 +20,6 @@ public class MenuOptionUpdateResponse {
     private final LocalDateTime createdAt;
     private final LocalDateTime updatedAt;
 
-    public MenuOptionUpdateResponse(Long id, Long menuId, String optionName, String contents, int optionPrice, OptionStatus optionStatus, LocalDateTime createdAt, LocalDateTime updatedAt) {
-        this.id = id;
-        this.menuId = menuId;
-        this.optionName = optionName;
-        this.contents = contents;
-        this.optionPrice = optionPrice;
-        this.optionStatus = optionStatus;
-        this.createdAt = createdAt;
-        this.updatedAt = updatedAt;
-    }
-
     public static MenuOptionUpdateResponse toDto(MenuOption menuOption) {
         return MenuOptionUpdateResponse.builder()
                 .id(menuOption.getId())

--- a/src/main/java/com/example/foodduck/menu/dto/response/MenuOptionUpdateResponse.java
+++ b/src/main/java/com/example/foodduck/menu/dto/response/MenuOptionUpdateResponse.java
@@ -2,50 +2,45 @@ package com.example.foodduck.menu.dto.response;
 
 import com.example.foodduck.menu.entity.MenuOption;
 import com.example.foodduck.menu.entity.OptionStatus;
+import lombok.Builder;
 import lombok.Getter;
 
 import java.time.LocalDateTime;
 
 @Getter
+@Builder
 public class MenuOptionUpdateResponse {
+
     private final Long id;
-
     private final Long menuId;
-
     private final String optionName;
-
     private final String contents;
-
-    private final int price;
-
+    private final int optionPrice;
     private final OptionStatus optionStatus;
-
     private final LocalDateTime createdAt;
-
     private final LocalDateTime updatedAt;
 
-    public MenuOptionUpdateResponse(Long id, Long menuId, String optionName, String contents, int price, OptionStatus optionStatus, LocalDateTime createdAt, LocalDateTime updatedAt) {
+    public MenuOptionUpdateResponse(Long id, Long menuId, String optionName, String contents, int optionPrice, OptionStatus optionStatus, LocalDateTime createdAt, LocalDateTime updatedAt) {
         this.id = id;
         this.menuId = menuId;
         this.optionName = optionName;
         this.contents = contents;
-        this.price = price;
+        this.optionPrice = optionPrice;
         this.optionStatus = optionStatus;
         this.createdAt = createdAt;
         this.updatedAt = updatedAt;
     }
 
-    //TODO: Builder로 변경
     public static MenuOptionUpdateResponse toDto(MenuOption menuOption) {
-        return new MenuOptionUpdateResponse(
-                menuOption.getId(),
-                menuOption.getMenu().getId(),
-                menuOption.getOptionName(),
-                menuOption.getContents(),
-                menuOption.getOptionPrice(),
-                menuOption.getOptionStatus(),
-                menuOption.getCreatedAt(),
-                menuOption.getUpdatedAt()
-        );
+        return MenuOptionUpdateResponse.builder()
+                .id(menuOption.getId())
+                .menuId(menuOption.getMenu().getId())
+                .optionName(menuOption.getOptionName())
+                .contents(menuOption.getContents())
+                .optionPrice(menuOption.getOptionPrice())
+                .optionStatus(menuOption.getOptionStatus())
+                .createdAt(menuOption.getCreatedAt())
+                .updatedAt(menuOption.getUpdatedAt())
+                .build();
     }
 }

--- a/src/main/java/com/example/foodduck/menu/dto/response/MenuOptionUpdateResponse.java
+++ b/src/main/java/com/example/foodduck/menu/dto/response/MenuOptionUpdateResponse.java
@@ -1,0 +1,51 @@
+package com.example.foodduck.menu.dto.response;
+
+import com.example.foodduck.menu.entity.MenuOption;
+import com.example.foodduck.menu.entity.OptionStatus;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+public class MenuOptionUpdateResponse {
+    private final Long id;
+
+    private final Long menuId;
+
+    private final String optionName;
+
+    private final String contents;
+
+    private final int price;
+
+    private final OptionStatus optionStatus;
+
+    private final LocalDateTime createdAt;
+
+    private final LocalDateTime updatedAt;
+
+    public MenuOptionUpdateResponse(Long id, Long menuId, String optionName, String contents, int price, OptionStatus optionStatus, LocalDateTime createdAt, LocalDateTime updatedAt) {
+        this.id = id;
+        this.menuId = menuId;
+        this.optionName = optionName;
+        this.contents = contents;
+        this.price = price;
+        this.optionStatus = optionStatus;
+        this.createdAt = createdAt;
+        this.updatedAt = updatedAt;
+    }
+
+    //TODO: Builder로 변경
+    public static MenuOptionUpdateResponse toDto(MenuOption menuOption) {
+        return new MenuOptionUpdateResponse(
+                menuOption.getId(),
+                menuOption.getMenu().getId(),
+                menuOption.getOptionName(),
+                menuOption.getContents(),
+                menuOption.getOptionPrice(),
+                menuOption.getOptionStatus(),
+                menuOption.getCreatedAt(),
+                menuOption.getUpdatedAt()
+        );
+    }
+}

--- a/src/main/java/com/example/foodduck/menu/dto/response/MenuResponse.java
+++ b/src/main/java/com/example/foodduck/menu/dto/response/MenuResponse.java
@@ -2,46 +2,42 @@ package com.example.foodduck.menu.dto.response;
 
 import com.example.foodduck.menu.entity.Menu;
 import com.example.foodduck.menu.entity.MenuState;
+import lombok.Builder;
 import lombok.Getter;
 
 import java.time.LocalDateTime;
 
 @Getter
+@Builder
 public class MenuResponse {
+
     private final Long id;
-
     private final Long storeId;
-
     private final String menuName;
-
-    private final int price;
-
+    private final int optionPrice;
     private final MenuState menuState;
-
     private final LocalDateTime createdAt;
-
     private final LocalDateTime updatedAt;
 
-    public MenuResponse(Long id, Long storeId, String menuName, int price, MenuState menuState, LocalDateTime createdAt, LocalDateTime updatedAt) {
+    public MenuResponse(Long id, Long storeId, String menuName, int optionPrice, MenuState menuState, LocalDateTime createdAt, LocalDateTime updatedAt) {
         this.id = id;
         this.storeId = storeId;
         this.menuName = menuName;
-        this.price = price;
+        this.optionPrice = optionPrice;
         this.menuState = menuState;
         this.createdAt = createdAt;
         this.updatedAt = updatedAt;
     }
 
-    //TODO: Builder로 변경
     public static MenuResponse toDto(Menu menu) {
-        return new MenuResponse (
-                menu.getId(),
-                menu.getStore().getId(),
-                menu.getMenuName(),
-                menu.getPrice(),
-                menu.getMenuState(),
-                menu.getCreatedAt(),
-                menu.getUpdatedAt()
-        );
+        return MenuResponse.builder()
+                .id(menu.getId())
+                .storeId(menu.getStore().getId())
+                .menuName(menu.getMenuName())
+                .optionPrice(menu.getPrice())
+                .menuState(menu.getMenuState())
+                .createdAt(menu.getCreatedAt())
+                .updatedAt(menu.getUpdatedAt())
+                .build();
     }
 }

--- a/src/main/java/com/example/foodduck/menu/dto/response/MenuResponse.java
+++ b/src/main/java/com/example/foodduck/menu/dto/response/MenuResponse.java
@@ -14,27 +14,17 @@ public class MenuResponse {
     private final Long id;
     private final Long storeId;
     private final String menuName;
-    private final int optionPrice;
+    private final int price;
     private final MenuState menuState;
     private final LocalDateTime createdAt;
     private final LocalDateTime updatedAt;
-
-    public MenuResponse(Long id, Long storeId, String menuName, int optionPrice, MenuState menuState, LocalDateTime createdAt, LocalDateTime updatedAt) {
-        this.id = id;
-        this.storeId = storeId;
-        this.menuName = menuName;
-        this.optionPrice = optionPrice;
-        this.menuState = menuState;
-        this.createdAt = createdAt;
-        this.updatedAt = updatedAt;
-    }
 
     public static MenuResponse toDto(Menu menu) {
         return MenuResponse.builder()
                 .id(menu.getId())
                 .storeId(menu.getStore().getId())
                 .menuName(menu.getMenuName())
-                .optionPrice(menu.getPrice())
+                .price(menu.getPrice())
                 .menuState(menu.getMenuState())
                 .createdAt(menu.getCreatedAt())
                 .updatedAt(menu.getUpdatedAt())

--- a/src/main/java/com/example/foodduck/menu/dto/response/MenuUpdateResponse.java
+++ b/src/main/java/com/example/foodduck/menu/dto/response/MenuUpdateResponse.java
@@ -2,11 +2,13 @@ package com.example.foodduck.menu.dto.response;
 
 import com.example.foodduck.menu.entity.Menu;
 import com.example.foodduck.menu.entity.MenuState;
+import lombok.Builder;
 import lombok.Getter;
 
 import java.time.LocalDateTime;
 
 @Getter
+@Builder
 public class MenuUpdateResponse {
 
     private final Long id;
@@ -15,7 +17,7 @@ public class MenuUpdateResponse {
 
     private final String menuName;
 
-    private final int price;
+    private final int optionPrice;
 
     private final String category;
 
@@ -25,28 +27,27 @@ public class MenuUpdateResponse {
 
     private final LocalDateTime updatedAt;
 
-    public MenuUpdateResponse(Long id, Long storeId, String menuName, int price,String category, MenuState menuState, LocalDateTime createdAt, LocalDateTime updatedAt) {
+    public MenuUpdateResponse(Long id, Long storeId, String menuName, int optionPrice, String category, MenuState menuState, LocalDateTime createdAt, LocalDateTime updatedAt) {
         this.id = id;
         this.storeId = storeId;
         this.menuName = menuName;
-        this.price = price;
+        this.optionPrice = optionPrice;
         this.category = category;
         this.menuState = menuState;
         this.createdAt = createdAt;
         this.updatedAt = updatedAt;
     }
 
-    //TODO: Builder로 변경
     public static MenuUpdateResponse toDto(Menu menu) {
-        return new MenuUpdateResponse (
-                menu.getId(),
-                menu.getStore().getId(),
-                menu.getMenuName(),
-                menu.getPrice(),
-                menu.getCategory(),
-                menu.getMenuState(),
-                menu.getCreatedAt(),
-                menu.getUpdatedAt()
-        );
+        return MenuUpdateResponse.builder()
+                .id(menu.getId())
+                .storeId(menu.getStore().getId())
+                .menuName(menu.getMenuName())
+                .optionPrice(menu.getPrice())
+                .category(menu.getCategory())
+                .menuState(menu.getMenuState())
+                .createdAt(menu.getCreatedAt())
+                .updatedAt(menu.getUpdatedAt())
+                .build();
     }
 }

--- a/src/main/java/com/example/foodduck/menu/dto/response/MenuUpdateResponse.java
+++ b/src/main/java/com/example/foodduck/menu/dto/response/MenuUpdateResponse.java
@@ -17,17 +17,20 @@ public class MenuUpdateResponse {
 
     private final int price;
 
+    private final String category;
+
     private final MenuState menuState;
 
     private final LocalDateTime createdAt;
 
     private final LocalDateTime updatedAt;
 
-    public MenuUpdateResponse(Long id, Long storeId, String menuName, int price, MenuState menuState, LocalDateTime createdAt, LocalDateTime updatedAt) {
+    public MenuUpdateResponse(Long id, Long storeId, String menuName, int price,String category, MenuState menuState, LocalDateTime createdAt, LocalDateTime updatedAt) {
         this.id = id;
         this.storeId = storeId;
         this.menuName = menuName;
         this.price = price;
+        this.category = category;
         this.menuState = menuState;
         this.createdAt = createdAt;
         this.updatedAt = updatedAt;
@@ -40,6 +43,7 @@ public class MenuUpdateResponse {
                 menu.getStore().getId(),
                 menu.getMenuName(),
                 menu.getPrice(),
+                menu.getCategory(),
                 menu.getMenuState(),
                 menu.getCreatedAt(),
                 menu.getUpdatedAt()

--- a/src/main/java/com/example/foodduck/menu/dto/response/MenuWithOptionResponse.java
+++ b/src/main/java/com/example/foodduck/menu/dto/response/MenuWithOptionResponse.java
@@ -1,33 +1,42 @@
 package com.example.foodduck.menu.dto.response;
 
 import com.example.foodduck.menu.entity.Menu;
+import com.example.foodduck.menu.entity.MenuOption;
 import com.example.foodduck.menu.entity.MenuState;
+
 import lombok.Builder;
 import lombok.Getter;
 
 import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Getter
 @Builder
-public class MenuUpdateResponse {
+public class MenuWithOptionResponse {
 
     private final Long id;
     private final Long storeId;
     private final String menuName;
-    private final int optionPrice;
-    private final String category;
+    private final int price;
     private final MenuState menuState;
+    private final List<MenuOptionCreateResponse> menuOptionList;
     private final LocalDateTime createdAt;
     private final LocalDateTime updatedAt;
 
-    public static MenuUpdateResponse toDto(Menu menu) {
-        return MenuUpdateResponse.builder()
+    public static MenuWithOptionResponse toDto(Menu menu, List<MenuOption> menuOptionList) {
+
+        List<MenuOptionCreateResponse> menuOptions = menuOptionList.stream()
+                .map(MenuOptionCreateResponse::toDto)
+                .collect(Collectors.toList());
+
+        return MenuWithOptionResponse.builder()
                 .id(menu.getId())
                 .storeId(menu.getStore().getId())
                 .menuName(menu.getMenuName())
-                .optionPrice(menu.getPrice())
-                .category(menu.getCategory())
+                .price(menu.getPrice())
                 .menuState(menu.getMenuState())
+                .menuOptionList(menuOptions)
                 .createdAt(menu.getCreatedAt())
                 .updatedAt(menu.getUpdatedAt())
                 .build();

--- a/src/main/java/com/example/foodduck/menu/entity/Menu.java
+++ b/src/main/java/com/example/foodduck/menu/entity/Menu.java
@@ -22,6 +22,8 @@ public class Menu extends BaseEntity {
 
     private int price;
 
+    private String category;
+
     @Enumerated(EnumType.STRING)
     private MenuState menuState;
 
@@ -33,9 +35,10 @@ public class Menu extends BaseEntity {
 
     }
 
-    public Menu(String menuName, int price, Store store) {
+    public Menu(String menuName, int price, String category, Store store) {
         this.menuName = menuName;
         this.price = price;
+        this.category = category;
         this.menuState = ON_SALE;
         this.store = store;
     }

--- a/src/main/java/com/example/foodduck/menu/entity/Menu.java
+++ b/src/main/java/com/example/foodduck/menu/entity/Menu.java
@@ -58,4 +58,8 @@ public class Menu extends BaseEntity {
     public void deleteMenu() {
         this.menuState = REMOVED;
     }
+
+    public void updateMenuCategory(String category) {
+        this.category = category;
+    }
 }

--- a/src/main/java/com/example/foodduck/menu/entity/Menu.java
+++ b/src/main/java/com/example/foodduck/menu/entity/Menu.java
@@ -5,6 +5,7 @@ import com.example.foodduck.store.entity.Store;
 import jakarta.persistence.*;
 
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import static com.example.foodduck.menu.entity.MenuState.ON_SALE;
 import static com.example.foodduck.menu.entity.MenuState.REMOVED;
@@ -12,6 +13,7 @@ import static com.example.foodduck.menu.entity.MenuState.REMOVED;
 @Getter
 @Entity
 @Table(name = "menus")
+@NoArgsConstructor
 public class Menu extends BaseEntity {
 
     @Id
@@ -30,10 +32,6 @@ public class Menu extends BaseEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "store_id")
     private Store store;
-
-    public Menu() {
-
-    }
 
     public Menu(Long menuId) {
         this.id = menuId;

--- a/src/main/java/com/example/foodduck/menu/entity/Menu.java
+++ b/src/main/java/com/example/foodduck/menu/entity/Menu.java
@@ -7,6 +7,9 @@ import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import static com.example.foodduck.menu.entity.MenuState.ON_SALE;
 import static com.example.foodduck.menu.entity.MenuState.REMOVED;
 
@@ -32,6 +35,9 @@ public class Menu extends BaseEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "store_id")
     private Store store;
+
+    @OneToMany(mappedBy =  "menu",fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+    private final List<MenuOption> menuOptionList = new ArrayList<>();
 
     public Menu(Long menuId) {
         this.id = menuId;

--- a/src/main/java/com/example/foodduck/menu/entity/Menu.java
+++ b/src/main/java/com/example/foodduck/menu/entity/Menu.java
@@ -35,6 +35,10 @@ public class Menu extends BaseEntity {
 
     }
 
+    public Menu(Long menuId) {
+        this.id = menuId;
+    }
+
     public Menu(String menuName, int price, String category, Store store) {
         this.menuName = menuName;
         this.price = price;

--- a/src/main/java/com/example/foodduck/menu/entity/MenuOption.java
+++ b/src/main/java/com/example/foodduck/menu/entity/MenuOption.java
@@ -2,6 +2,8 @@ package com.example.foodduck.menu.entity;
 
 import com.example.foodduck.common.entity.BaseEntity;
 import jakarta.persistence.*;
+import jakarta.validation.constraints.PositiveOrZero;
+import jakarta.validation.constraints.Size;
 import lombok.Getter;
 
 @Getter
@@ -36,5 +38,22 @@ public class MenuOption extends BaseEntity {
         this.optionPrice = optionPrice;
         this.optionStatus = OptionStatus.ON_SALE;
         this.menu = menu;
+    }
+
+    public void updateMenuOption(String optionName) {
+        this.optionName = optionName;
+    }
+
+    public void updateMenuOptionContents(String contents) {
+        this.contents = contents;
+    }
+
+    public void updateMenuOptionPrice(int optionPrice) {
+        this.optionPrice = optionPrice;
+    }
+
+    public void updateOptionStatus(OptionStatus optionStatus) {
+        this.optionStatus = optionStatus;
+
     }
 }

--- a/src/main/java/com/example/foodduck/menu/entity/MenuOption.java
+++ b/src/main/java/com/example/foodduck/menu/entity/MenuOption.java
@@ -54,6 +54,9 @@ public class MenuOption extends BaseEntity {
 
     public void updateOptionStatus(OptionStatus optionStatus) {
         this.optionStatus = optionStatus;
+    }
 
+    public void deleteMenuOption(OptionStatus optionStatus) {
+        this.optionStatus = optionStatus;
     }
 }

--- a/src/main/java/com/example/foodduck/menu/entity/MenuOption.java
+++ b/src/main/java/com/example/foodduck/menu/entity/MenuOption.java
@@ -1,0 +1,40 @@
+package com.example.foodduck.menu.entity;
+
+import com.example.foodduck.common.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.Getter;
+
+@Getter
+@Entity
+@Table(name = "menu_options")
+public class MenuOption extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String optionName;
+
+    private String contents;
+
+    private int optionPrice;
+
+    @Enumerated(EnumType.STRING)
+    private OptionStatus optionStatus;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "menu_id")
+    private Menu menu;
+
+    public MenuOption() {
+
+    }
+
+    public MenuOption(String optionName, String contents, int optionPrice, Menu menu) {
+        this.optionName = optionName;
+        this.contents = contents;
+        this.optionPrice = optionPrice;
+        this.optionStatus = OptionStatus.ON_SALE;
+        this.menu = menu;
+    }
+}

--- a/src/main/java/com/example/foodduck/menu/entity/MenuOption.java
+++ b/src/main/java/com/example/foodduck/menu/entity/MenuOption.java
@@ -2,13 +2,13 @@ package com.example.foodduck.menu.entity;
 
 import com.example.foodduck.common.entity.BaseEntity;
 import jakarta.persistence.*;
-import jakarta.validation.constraints.PositiveOrZero;
-import jakarta.validation.constraints.Size;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
 @Entity
 @Table(name = "menu_options")
+@NoArgsConstructor
 public class MenuOption extends BaseEntity {
 
     @Id
@@ -27,10 +27,6 @@ public class MenuOption extends BaseEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "menu_id")
     private Menu menu;
-
-    public MenuOption() {
-
-    }
 
     public MenuOption(String optionName, String contents, int optionPrice, Menu menu) {
         this.optionName = optionName;
@@ -56,7 +52,7 @@ public class MenuOption extends BaseEntity {
         this.optionStatus = optionStatus;
     }
 
-    public void deleteMenuOption(OptionStatus optionStatus) {
-        this.optionStatus = optionStatus;
+    public void deleteMenuOption() {
+        this.optionStatus = OptionStatus.REMOVED;
     }
 }

--- a/src/main/java/com/example/foodduck/menu/entity/MenuOption.java
+++ b/src/main/java/com/example/foodduck/menu/entity/MenuOption.java
@@ -28,6 +28,7 @@ public class MenuOption extends BaseEntity {
     @JoinColumn(name = "menu_id")
     private Menu menu;
 
+
     public MenuOption(String optionName, String contents, int optionPrice, Menu menu) {
         this.optionName = optionName;
         this.contents = contents;

--- a/src/main/java/com/example/foodduck/menu/entity/OptionStatus.java
+++ b/src/main/java/com/example/foodduck/menu/entity/OptionStatus.java
@@ -1,0 +1,7 @@
+package com.example.foodduck.menu.entity;
+
+public enum OptionStatus {
+    ON_SALE,
+    SOLD_OUT,
+    REMOVED
+}

--- a/src/main/java/com/example/foodduck/menu/repository/MenuOptionRepository.java
+++ b/src/main/java/com/example/foodduck/menu/repository/MenuOptionRepository.java
@@ -1,8 +1,13 @@
 package com.example.foodduck.menu.repository;
 
+import com.example.foodduck.menu.entity.Menu;
 import com.example.foodduck.menu.entity.MenuOption;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface MenuOptionRepository extends JpaRepository<MenuOption, Long> {
     boolean existsByContents(String contents);
+
+    List<MenuOption> findAllByMenuId(Long menuId);
 }

--- a/src/main/java/com/example/foodduck/menu/repository/MenuOptionRepository.java
+++ b/src/main/java/com/example/foodduck/menu/repository/MenuOptionRepository.java
@@ -1,0 +1,8 @@
+package com.example.foodduck.menu.repository;
+
+import com.example.foodduck.menu.entity.MenuOption;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MenuOptionRepository extends JpaRepository<MenuOption, Long> {
+    boolean existsByContents(String contents);
+}

--- a/src/main/java/com/example/foodduck/menu/repository/MenuRepository.java
+++ b/src/main/java/com/example/foodduck/menu/repository/MenuRepository.java
@@ -1,7 +1,21 @@
 package com.example.foodduck.menu.repository;
 
 import com.example.foodduck.menu.entity.Menu;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface MenuRepository extends JpaRepository<Menu, Long> {
+
+    @Query("SELECT m FROM Menu m " +
+            "WHERE m.store.id = :storeId " +
+            "AND (:menuName IS NULL OR m.menuName LIKE CONCAT('%', :menuName, '%')) " +
+            "AND (:category IS NULL OR m.category = :category)")
+    Page<Menu> findAllByStoreId(
+            Long storeId,
+            @Param("menuName") String menuName,
+            @Param("category") String category,
+            Pageable pageable);
 }

--- a/src/main/java/com/example/foodduck/menu/repository/MenuRepository.java
+++ b/src/main/java/com/example/foodduck/menu/repository/MenuRepository.java
@@ -1,6 +1,8 @@
 package com.example.foodduck.menu.repository;
 
 import com.example.foodduck.menu.entity.Menu;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -18,4 +20,6 @@ public interface MenuRepository extends JpaRepository<Menu, Long> {
             @Param("menuName") String menuName,
             @Param("category") String category,
             Pageable pageable);
+
+    boolean existsByMenuName(String menuName);
 }

--- a/src/main/java/com/example/foodduck/menu/repository/MenuRepository.java
+++ b/src/main/java/com/example/foodduck/menu/repository/MenuRepository.java
@@ -1,20 +1,21 @@
 package com.example.foodduck.menu.repository;
 
 import com.example.foodduck.menu.entity.Menu;
-import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.Size;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 public interface MenuRepository extends JpaRepository<Menu, Long> {
 
+    @EntityGraph(attributePaths = {"store"})
     @Query("SELECT m FROM Menu m " +
             "WHERE m.store.id = :storeId " +
             "AND (:menuName IS NULL OR m.menuName LIKE CONCAT('%', :menuName, '%')) " +
-            "AND (:category IS NULL OR m.category = :category)")
+            "AND (:category IS NULL OR m.category = :category)" +
+            "AND m.menuState != 'REMOVED'" )
     Page<Menu> findAllByStoreId(
             Long storeId,
             @Param("menuName") String menuName,

--- a/src/main/java/com/example/foodduck/menu/service/MenuOptionService.java
+++ b/src/main/java/com/example/foodduck/menu/service/MenuOptionService.java
@@ -41,7 +41,7 @@ public class MenuOptionService {
         MenuOption savedMenuOption = menuOptionRepository.save(new MenuOption(
                 menuOptionCreateRequest.getOptionName(),
                 menuOptionCreateRequest.getContents(),
-                menuOptionCreateRequest.getPrice(),
+                menuOptionCreateRequest.getOptionPrice(),
                 new Menu(menuId))
         );
 
@@ -57,26 +57,28 @@ public class MenuOptionService {
 
         Menu findMenu = menuService.findMenuOrElseThrow(findMenuOption.getMenu().getId());
 
-        //본인 가게의 메뉴 옵션만 수정 가능
-        if (!findUser.getId().equals(findMenu.getStore().getOwner().getId())) {
-            throw new InvalidCredentialException("본인 가게의 메뉴 옵션만 수정할 수 있습니다.");
-        }
-
+        /**
+         * (1): option이 입력되지 않은 경우
+         * (2): contents가 입력되지 않은 경우
+         * (3): optionPrice가 입력되었고 변경된 경우
+         * (4): optionStatus가 입력되고 해당 값이 SOLD_OUT인 경우
+         * (5): optionStatus가 입력되고 해당 값이 ON_SALE인 경우
+         */
         if (!StringUtils.hasText(menuOptionUpdateRequest.getOption())) {
-            findMenuOption.updateMenuOption(menuOptionUpdateRequest.getOption()); //TODO:  변수명 다 바꾸기
+            findMenuOption.updateMenuOption(menuOptionUpdateRequest.getOption()); // (1)
         }
         if (!StringUtils.hasText(menuOptionUpdateRequest.getContents())) {
-            findMenuOption.updateMenuOptionContents(menuOptionUpdateRequest.getContents());
+            findMenuOption.updateMenuOptionContents(menuOptionUpdateRequest.getContents()); // (2)
         }
-        if (findMenuOption.getOptionPrice() != menuOptionUpdateRequest.getPrice()) { //TODO: 변수명 맞추기
-            findMenuOption.updateMenuOptionPrice(menuOptionUpdateRequest.getPrice());
+        if (findMenuOption.getOptionPrice() != menuOptionUpdateRequest.getOptionPrice()) {
+            findMenuOption.updateMenuOptionPrice(menuOptionUpdateRequest.getOptionPrice()); // (3)
         }
         if (!findMenuOption.getOptionStatus().equals(menuOptionUpdateRequest.getOptionStatus())) {
             if (OptionStatus.SOLD_OUT.equals(menuOptionUpdateRequest.getOptionStatus())) {
-                findMenuOption.updateOptionStatus(OptionStatus.SOLD_OUT);
+                findMenuOption.updateOptionStatus(OptionStatus.SOLD_OUT); // (4)
             }
             if (OptionStatus.ON_SALE.equals(menuOptionUpdateRequest.getOptionStatus())) {
-                findMenuOption.updateOptionStatus(OptionStatus.ON_SALE);
+                findMenuOption.updateOptionStatus(OptionStatus.ON_SALE); // (5)
             }
         }
 
@@ -97,6 +99,6 @@ public class MenuOptionService {
             throw new InvalidCredentialException("본인 가게의 메뉴 옵션만 수정할 수 있습니다.");
         }
 
-        findMenuOption.deleteMenuOption(OptionStatus.REMOVED);
+        findMenuOption.deleteMenuOption();
     }
 }

--- a/src/main/java/com/example/foodduck/menu/service/MenuOptionService.java
+++ b/src/main/java/com/example/foodduck/menu/service/MenuOptionService.java
@@ -2,14 +2,21 @@ package com.example.foodduck.menu.service;
 
 import com.example.foodduck.exception.InvalidCredentialException;
 import com.example.foodduck.menu.dto.request.MenuOptionCreateRequest;
+import com.example.foodduck.menu.dto.request.MenuOptionUpdateRequest;
 import com.example.foodduck.menu.dto.response.MenuOptionCreateResponse;
+import com.example.foodduck.menu.dto.response.MenuOptionUpdateResponse;
 import com.example.foodduck.menu.entity.Menu;
 import com.example.foodduck.menu.entity.MenuOption;
+import com.example.foodduck.menu.entity.OptionStatus;
 import com.example.foodduck.menu.repository.MenuOptionRepository;
 import com.example.foodduck.user.entity.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
+
+import static com.example.foodduck.menu.entity.MenuState.ON_SALE;
+import static com.example.foodduck.menu.entity.MenuState.SOLD_OUT;
 
 @Service
 @RequiredArgsConstructor
@@ -42,5 +49,40 @@ public class MenuOptionService {
         );
 
         return  MenuOptionCreateResponse.toDto(savedMenuOption);
+    }
+
+    @Transactional
+    public MenuOptionUpdateResponse updateMenuOption(Long optionId, MenuOptionUpdateRequest menuOptionUpdateRequest) {
+        User findUser = menuService.getAuthenticatedUser();
+
+        MenuOption findMenuOption = menuOptionRepository.findById(optionId)
+                        .orElseThrow(() -> new IllegalArgumentException("메뉴 옵션을 찾을 수 없습니다."));
+
+        Menu findMenu = menuService.findMenuOrElseThrow(findMenuOption.getMenu().getId());
+
+        //본인 가게의 메뉴 옵션만 수정 가능
+        if (!findUser.getId().equals(findMenu.getStore().getOwner().getId())) {
+            throw new InvalidCredentialException("본인 가게의 메뉴 옵션만 수정할 수 있습니다.");
+        }
+
+        if (!StringUtils.hasText(menuOptionUpdateRequest.getOption())) {
+            findMenuOption.updateMenuOption(menuOptionUpdateRequest.getOption()); //TODO:  변수명 다 바꾸기
+        }
+        if (!StringUtils.hasText(menuOptionUpdateRequest.getContents())) {
+            findMenuOption.updateMenuOptionContents(menuOptionUpdateRequest.getContents());
+        }
+        if (findMenuOption.getOptionPrice() != menuOptionUpdateRequest.getPrice()) { //TODO: 변수명 맞추기
+            findMenuOption.updateMenuOptionPrice(menuOptionUpdateRequest.getPrice());
+        }
+        if (!findMenuOption.getOptionStatus().equals(menuOptionUpdateRequest.getOptionStatus())) {
+            if (OptionStatus.SOLD_OUT.equals(menuOptionUpdateRequest.getOptionStatus())) {
+                findMenuOption.updateOptionStatus(OptionStatus.SOLD_OUT);
+            }
+            if (OptionStatus.ON_SALE.equals(menuOptionUpdateRequest.getOptionStatus())) {
+                findMenuOption.updateOptionStatus(OptionStatus.ON_SALE);
+            }
+        }
+
+        return MenuOptionUpdateResponse.toDto(findMenuOption);
     }
 }

--- a/src/main/java/com/example/foodduck/menu/service/MenuOptionService.java
+++ b/src/main/java/com/example/foodduck/menu/service/MenuOptionService.java
@@ -15,9 +15,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StringUtils;
 
-import static com.example.foodduck.menu.entity.MenuState.ON_SALE;
-import static com.example.foodduck.menu.entity.MenuState.SOLD_OUT;
-
 @Service
 @RequiredArgsConstructor
 public class MenuOptionService {
@@ -84,5 +81,22 @@ public class MenuOptionService {
         }
 
         return MenuOptionUpdateResponse.toDto(findMenuOption);
+    }
+
+    @Transactional
+    public void deleteMenuOption(Long optionId) {
+        User findUser = menuService.getAuthenticatedUser();
+
+        MenuOption findMenuOption = menuOptionRepository.findById(optionId)
+                .orElseThrow(() -> new IllegalArgumentException("메뉴 옵션을 찾을 수 없습니다."));
+
+        Menu findMenu = menuService.findMenuOrElseThrow(findMenuOption.getMenu().getId());
+
+        //본인 가게의 메뉴 옵션만 수정 가능
+        if (!findUser.getId().equals(findMenu.getStore().getOwner().getId())) {
+            throw new InvalidCredentialException("본인 가게의 메뉴 옵션만 수정할 수 있습니다.");
+        }
+
+        findMenuOption.deleteMenuOption(OptionStatus.REMOVED);
     }
 }

--- a/src/main/java/com/example/foodduck/menu/service/MenuOptionService.java
+++ b/src/main/java/com/example/foodduck/menu/service/MenuOptionService.java
@@ -1,0 +1,46 @@
+package com.example.foodduck.menu.service;
+
+import com.example.foodduck.exception.InvalidCredentialException;
+import com.example.foodduck.menu.dto.request.MenuOptionCreateRequest;
+import com.example.foodduck.menu.dto.response.MenuOptionCreateResponse;
+import com.example.foodduck.menu.entity.Menu;
+import com.example.foodduck.menu.entity.MenuOption;
+import com.example.foodduck.menu.repository.MenuOptionRepository;
+import com.example.foodduck.user.entity.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class MenuOptionService {
+
+    private final MenuOptionRepository menuOptionRepository;
+    private final MenuService menuService;
+
+    @Transactional
+    public MenuOptionCreateResponse createMenuOption (Long menuId, MenuOptionCreateRequest menuOptionCreateRequest) {
+        User findUser = menuService.getAuthenticatedUser();
+
+        Menu findMenu = menuService.findMenuOrElseThrow(menuId);
+
+        //본인 가게의 메뉴에만 옵션 추가 가능
+        if (!findUser.getId().equals(findMenu.getStore().getOwner().getId())) {
+            throw new InvalidCredentialException("본인 가게의 메뉴에만 옵션을 추가할 수 있습니다.");
+        }
+
+        //이미 존재하는 옵션 내용인 경우
+        if (menuOptionRepository.existsByContents(menuOptionCreateRequest.getContents())) {
+            throw new IllegalArgumentException("이미 존재하는 옵션 내용 입니다.");
+        }
+
+        MenuOption savedMenuOption = menuOptionRepository.save(new MenuOption(
+                menuOptionCreateRequest.getOptionName(),
+                menuOptionCreateRequest.getContents(),
+                menuOptionCreateRequest.getPrice(),
+                new Menu(menuId))
+        );
+
+        return  MenuOptionCreateResponse.toDto(savedMenuOption);
+    }
+}

--- a/src/main/java/com/example/foodduck/menu/service/MenuService.java
+++ b/src/main/java/com/example/foodduck/menu/service/MenuService.java
@@ -48,6 +48,7 @@ public class MenuService {
             throw new InvalidCredentialException("본인 가게에만 메뉴 등록이 가능합니다.");
         }
 
+        //이미 메뉴가 존재하는 경우
         if (menuRepository.existsByMenuName(menuCreateRequest.getMenuName())) {
             throw new IllegalArgumentException("이미 존재하는 메뉴입니다.");
         }
@@ -58,7 +59,7 @@ public class MenuService {
         return MenuCreateResponse.toDto(menu);
     }
 
-    //TODO: 정렬 기준 추가하기 (리뷰 순, 주문 순)
+
     @Transactional(readOnly = true)
     public Page<MenuResponse> getMenus(Long storeId, int page, int size, String menuName, String category, String sortCondition) {
 

--- a/src/main/java/com/example/foodduck/menu/service/MenuService.java
+++ b/src/main/java/com/example/foodduck/menu/service/MenuService.java
@@ -48,7 +48,7 @@ public class MenuService {
             throw new InvalidCredentialException("본인 가게에만 메뉴 등록이 가능합니다.");
         }
 
-        Menu menu = new Menu(menuCreateRequest.getMenuName(), menuCreateRequest.getPrice(), new Store(storeId));
+        Menu menu = new Menu(menuCreateRequest.getMenuName(), menuCreateRequest.getPrice(), menuCreateRequest.getCategory(), new Store(storeId));
 
         menuRepository.save(menu);
         return MenuCreateResponse.toDto(menu);

--- a/src/main/java/com/example/foodduck/menu/service/MenuService.java
+++ b/src/main/java/com/example/foodduck/menu/service/MenuService.java
@@ -48,6 +48,10 @@ public class MenuService {
             throw new InvalidCredentialException("본인 가게에만 메뉴 등록이 가능합니다.");
         }
 
+        if (menuRepository.existsByMenuName(menuCreateRequest.getMenuName())) {
+            throw new IllegalArgumentException("이미 존재하는 메뉴입니다.");
+        }
+
         Menu menu = new Menu(menuCreateRequest.getMenuName(), menuCreateRequest.getPrice(), menuCreateRequest.getCategory(), new Store(storeId));
 
         menuRepository.save(menu);

--- a/src/main/java/com/example/foodduck/menu/service/MenuService.java
+++ b/src/main/java/com/example/foodduck/menu/service/MenuService.java
@@ -135,12 +135,12 @@ public class MenuService {
         findMenu.deleteMenu();
     }
 
-    private Menu findMenuOrElseThrow(Long menuId) {
+    public Menu findMenuOrElseThrow(Long menuId) {
         return menuRepository.findById(menuId)
                 .orElseThrow(() -> new IllegalArgumentException("메뉴를 찾을 수 없습니다."));
     }
 
-    private User getAuthenticatedUser() {
+    public User getAuthenticatedUser() {
         //로그인한 유저 정보 추출
         Object principal = SecurityContextHolder.getContext().getAuthentication().getPrincipal();
         UserDetails userDetails = (UserDetails)principal;

--- a/src/main/java/com/example/foodduck/menu/service/MenuService.java
+++ b/src/main/java/com/example/foodduck/menu/service/MenuService.java
@@ -3,10 +3,10 @@ package com.example.foodduck.menu.service;
 import com.example.foodduck.exception.InvalidCredentialException;
 import com.example.foodduck.menu.dto.request.MenuCreateRequest;
 import com.example.foodduck.menu.dto.request.MenuUpdateRequest;
-import com.example.foodduck.menu.dto.response.MenuCreateResponse;
-import com.example.foodduck.menu.dto.response.MenuResponse;
-import com.example.foodduck.menu.dto.response.MenuUpdateResponse;
+import com.example.foodduck.menu.dto.response.*;
 import com.example.foodduck.menu.entity.Menu;
+import com.example.foodduck.menu.entity.MenuOption;
+import com.example.foodduck.menu.repository.MenuOptionRepository;
 import com.example.foodduck.menu.repository.MenuRepository;
 import com.example.foodduck.store.entity.Store;
 import com.example.foodduck.store.repository.StoreRepository;
@@ -33,6 +33,7 @@ public class MenuService {
     private final MenuRepository menuRepository;
     private final UserRepository userRepository;
     private final StoreRepository storeRepository;
+    private final MenuOptionRepository menuOptionRepository;
 
     @Transactional
     public MenuCreateResponse createMenu(Long storeId, MenuCreateRequest menuCreateRequest) {
@@ -76,11 +77,13 @@ public class MenuService {
     }
 
     @Transactional(readOnly = true)
-    public MenuResponse getMenu(Long menuId) {
+    public MenuWithOptionResponse getMenu(Long menuId) {
 
         Menu findMenu = findMenuOrElseThrow(menuId);
 
-        return MenuResponse.toDto(findMenu);
+        List<MenuOption> menuOptions = menuOptionRepository.findAllByMenuId(findMenu.getId());
+
+        return MenuWithOptionResponse.toDto(findMenu, menuOptions);
     }
 
     @Transactional


### PR DESCRIPTION
**postman 테스트**

**API** 


**메뉴 등록**
```
POST localhost:8080/stores/1/menus

{
    "menuName": "라면",
    "price": 5000,
    "category": "추천 메뉴"
}
```
<br>

**메뉴 수정**
```
PATCH localhost:8080/menus/1/update

{
    "menuName": "김치찜",
    "price": 10000,
    "category": "대표 메뉴",
    "menuState": "SOLD_OUT"
}

```

<br>

**메뉴 삭제**
`DELETE localhost:8080/menus/1/delete`

<br>

**메뉴 전체 조회**

`GET localhost:8080/stores/1/menus?menuName=라면&category=대표 메뉴&sortCondition=createdAt`

-  가격, 등록일, 수정일으로 정렬해서 조회 가능

<br>

**메뉴 단건 조회**
`GET localhost:8080/menus/1`

<br>

**메뉴 옵션 등록**
```
POST localhost:8080/menus/1/options

{
    "optionName": "면 사리",
    "contents": "우동 사리",
    "price": 2000
}
```

<br>

**메뉴 옵션 수정**

```
PATCH localhost:8080/menus/options/1/update

{
    "option": "면 사리",
    "contents": "라면 사리",
    "price": 2000,
    "optionStatus": "SOLD_OUT"
}
```

<br>

**메뉴 옵션 삭제**

`DELETE localhost:8080/menus/options/1/delete`
